### PR TITLE
Updates Laravel framework dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   ],
   "require": {
     "php": "^8.0",
-    "laravel/framework": "^9.0|^10.0"
+    "laravel/framework": "^9.0|^10.0|^11.0|^12.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.5|^10.0",


### PR DESCRIPTION
Extends the allowed versions of the Laravel framework
to include versions 11 and 12.

This ensures compatibility with newer versions of the
framework and allows users to upgrade without encountering
dependency conflicts.
