### PR TITLE
Renames `ownerships()` to `possessions()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ $user->takeOwnershipFrom($post);
 
 Methods available on owner models:
 
-- `ownerships()` - Relationship to ownership records
+- `possessions()` - Relationship to ownership records
 - `ownables()` - Relationship to owned items
 - `owns($ownable)` - Check if owns a specific item
 - `giveOwnershipTo($ownable)` - Give ownership of an item

--- a/docs/index.html
+++ b/docs/index.html
@@ -364,7 +364,7 @@ $user->takeOwnershipFrom($post);
                     
                     <div class="space-y-6">
                         <div class="border-l-4 border-blue-500 pl-6">
-                            <h4 class="text-lg font-semibold text-gray-800 mb-2">ownerships()</h4>
+                            <h4 class="text-lg font-semibold text-gray-800 mb-2">possessions()</h4>
                             <p class="text-gray-600 mb-2">Get all ownership records where this model is the owner.</p>
                             <div class="bg-gray-100 p-3 rounded text-sm text-gray-700">
                                 <strong>Returns:</strong> \Illuminate\Database\Eloquent\Relations\MorphMany

--- a/src/Traits/HasOwnables.php
+++ b/src/Traits/HasOwnables.php
@@ -17,7 +17,7 @@ trait HasOwnables
      * 
      * @return \Illuminate\Database\Eloquent\Relations\MorphMany
      */
-    public function ownerships()
+    public function possessions()
     {
         return $this->morphMany(Ownership::class, 'owner');
     }

--- a/tests/Unit/HasOwnablesTraitTest.php
+++ b/tests/Unit/HasOwnablesTraitTest.php
@@ -14,7 +14,7 @@ class HasOwnablesTraitTest extends TestCase
     {
         $user = User::create(['name' => 'John Doe', 'email' => 'john@example.com']);
 
-        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Relations\MorphMany::class, $user->ownerships());
+        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Relations\MorphMany::class, $user->possessions());
     }
 
     /** @test */
@@ -180,7 +180,7 @@ class HasOwnablesTraitTest extends TestCase
 
         $this->assertTrue($user->owns($post1));
         $this->assertTrue($user->owns($post2));
-        $this->assertEquals(2, $user->ownerships()->count());
+        $this->assertEquals(2, $user->possessions()->count());
     }
 
     /** @test */


### PR DESCRIPTION
Updates the `ownerships()` relationship method to `possessions()`
for clarity and better semantic meaning, reflecting that a user
possesses items.

This change affects the trait, documentation, and tests.
