### PR TITLE
Fix: Incorrect Facade Accessor Name

### DIFF
--- a/src/Facades/Owner.php
+++ b/src/Facades/Owner.php
@@ -25,6 +25,6 @@ class Owner extends Facade
      */
     protected static function getFacadeAccessor()
     {
-        return 'owner';
+        return 'ownable.owner';
     }
 }


### PR DESCRIPTION
It seems the Owner facade accessor name is incorrect. The `OwnableServiceProvider` references it as `ownable.owner`, however the facade accessor had it as just `owner`.

This should fix #17 